### PR TITLE
[leetcode] 1557-Minimum Number of Vertices to Reach All Nodes

### DIFF
--- a/Graph/[leetcode] 1557-Minimum Number of Vertices to Reach All Nodes.swift
+++ b/Graph/[leetcode] 1557-Minimum Number of Vertices to Reach All Nodes.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// https://leetcode.com/problems/minimum-number-of-vertices-to-reach-all-nodes/
+class Solution {
+    func findSmallestSetOfVertices(_ n: Int, _ edges: [[Int]]) -> [Int] {
+        
+        var vertices: [Int] = Array(repeating: 0, count: n)
+
+        for edge in edges {
+            let (from, to) = (edge[0], edge[1])
+            vertices[to] += 1
+        }
+
+        return (0..<n).filter { vertices[$0] == 0 }
+    }
+}


### PR DESCRIPTION
<!-- 
제목예시:
[BOJ] 00000-문제이름 
[programmers] 00000-문제이름 
-->

### 체크리스트
- [x] [문제링크](https://leetcode.com/problems/minimum-number-of-vertices-to-reach-all-nodes/)
- [ ] 60 / 60: dfs로 잘못 접근함
- [x] 난이도(Label)를 지정했습니다.
- [x] 마일스톤을 지정했습니다.


### 풀이내용
- 시간복잡도: O(N+M) : N - 노드의 개수, M - edges의 개수
- 공간복잡도: O(N): N- 노드의 개수
- 그래프
